### PR TITLE
Rename read route from /:id to /get-user-by-id/:id

### DIFF
--- a/examples/eventsourcing-demo/src/read/shell/http/router.ts
+++ b/examples/eventsourcing-demo/src/read/shell/http/router.ts
@@ -31,7 +31,7 @@ readRouter.get(
 );
 
 readRouter.get(
-    '/:id',
+    '/get-user-by-id/:id',
     async (c) => {
         const id = c.req.param('id');
         const correlationId = getCorrelationId(c);


### PR DESCRIPTION
## Summary
- Renames the GET route `/:id` to `/get-user-by-id/:id` in the eventsourcing-demo read router for better clarity and consistency with the existing `/list-users` route naming convention.

## Test plan
- [x] `deno fmt --check` passes
- [x] `deno lint` passes
- [x] `deno test` passes (33/33)
- [x] No other references to the old route found in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)